### PR TITLE
use 7 digits for rate on CurrencyRate model

### DIFF
--- a/metasettings/migrations/0003_auto__chg_field_currencyrate_rate.py
+++ b/metasettings/migrations/0003_auto__chg_field_currencyrate_rate.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'CurrencyRate.rate'
+        db.alter_column(u'metasettings_currencyrate', 'rate', self.gf('django.db.models.fields.DecimalField')(max_digits=7, decimal_places=2))
+
+    def backwards(self, orm):
+
+        # Changing field 'CurrencyRate.rate'
+        db.alter_column(u'metasettings_currencyrate', 'rate', self.gf('django.db.models.fields.DecimalField')(max_digits=5, decimal_places=2))
+
+    models = {
+        u'metasettings.currencyrate': {
+            'Meta': {'object_name': 'CurrencyRate'},
+            'currency': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            'date_last_sync': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'month': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rate': ('django.db.models.fields.DecimalField', [], {'max_digits': '7', 'decimal_places': '2'}),
+            'year': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['metasettings']

--- a/metasettings/models.py
+++ b/metasettings/models.py
@@ -86,7 +86,7 @@ class CurrencyRateManager(models.Manager):
 
 class CurrencyRate(models.Model):
     currency = models.CharField(max_length=3, choices=settings.CURRENCY_LABELS, verbose_name=_('Currency'))
-    rate = models.DecimalField(verbose_name=_(u'Rate'), max_digits=5, decimal_places=2)
+    rate = models.DecimalField(verbose_name=_(u'Rate'), max_digits=7, decimal_places=2)
 
     month = models.PositiveIntegerField(null=True, blank=True)
     year = models.PositiveIntegerField(null=True, blank=True)


### PR DESCRIPTION
Some rates from openexchangerates.org have up to 5 digits before the comma.
Without this change the sync_rate commands fails with:
InvalidOperation: quantize result has too many digits for current context
