### PR TITLE
Make OpenExchangeRates app id parameter optionnal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.log
 *.pot
 *.pyc
+.coverage
 local_settings.py

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,8 @@ To import currency rates in a date range, run ::
 
 It will import for each months between the two dates the currency rates.
 
+The OpenExchangeRates app id can also be stored in the
+`OPENEXCHANGERATES_APP_ID` Django setting.
 
 If you can to convert an amount from on currency to another ::
 

--- a/metasettings/management/commands/sync_rates.py
+++ b/metasettings/management/commands/sync_rates.py
@@ -4,6 +4,7 @@ import requests
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from optparse import make_option
@@ -38,7 +39,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        self.app_id = options.get('app_id', None)
+        self.app_id = options.get('app_id', getattr(settings, 'OPENEXCHANGERATES_APP_ID'))
 
         if not self.app_id:
             raise CommandError('The openexchangerates APP ID is required')

--- a/metasettings/models.py
+++ b/metasettings/models.py
@@ -59,7 +59,7 @@ def convert_amount(from_currency, to_currency, amount, ceil=False,
 
 
 class CurrencyRateManager(models.Manager):
-    currency_choices = dict(settings.CURRENCY_CHOICES)
+    CURRENCY_CHOICES = dict(settings.CURRENCY_CHOICES)
 
     @cached_property
     def rates(self):
@@ -93,7 +93,7 @@ class CurrencyRateManager(models.Manager):
         was neither updated nor created then None is returned.
 
         """
-        if currency not in self.currency_choices:
+        if currency not in self.CURRENCY_CHOICES:
             return (None, False)
 
         try:
@@ -109,12 +109,10 @@ class CurrencyRateManager(models.Manager):
             existing_rate.rate = str(existing_rate.rate)
             rate = str("%.2f" % (rate))
 
-            if existing_rate.rate == rate:
-                return (None, False)
-            else:
+            if existing_rate.rate != rate:
                 existing_rate.rate = rate
                 existing_rate.save()
-                return (existing_rate, False)
+            return (existing_rate, False)
 
         except CurrencyRate.DoesNotExist:
             currency_rate = CurrencyRate()

--- a/metasettings/openexchangerates.py
+++ b/metasettings/openexchangerates.py
@@ -1,0 +1,36 @@
+import json
+import requests
+import logging
+from metasettings.models import CurrencyRate
+
+LOGGER = logging.getLogger(__name__)
+
+
+def rate_request(app_id, date=None):
+    url = 'http://openexchangerates.org/api'
+    if date:
+        url += '/historical/%s.json' % date.strftime("%Y-%m-%d")
+    else:
+        url += '/latest.json'
+
+    response = requests.get(url, params={'app_id': app_id})
+    if response.status_code == 200:
+        return json.loads(response.content)
+    else:
+        LOGGER.warning("Request to %s returned %s", url, response.status_code)
+
+
+def sync_rates(app_id, date=None):
+    result = rate_request(app_id, date=None)
+    if not result:
+        return
+    for currency, rate in result['rates'].iteritems():
+        currency_rate, created = CurrencyRate.objects.update_or_create(
+            currency, rate, date
+        )
+        if currency_rate:
+            if created:
+                msg = 'Create currency %s with %s'
+            else:
+                msg = 'Syncing currency %s with %s'
+            LOGGER.info(msg, currency, rate)

--- a/metasettings/openexchangerates.py
+++ b/metasettings/openexchangerates.py
@@ -16,8 +16,7 @@ def rate_request(app_id, date=None):
     response = requests.get(url, params={'app_id': app_id})
     if response.status_code == 200:
         return json.loads(response.content)
-    else:
-        LOGGER.warning("Request to %s returned %s", url, response.status_code)
+    LOGGER.warning("Request to %s returned %s", url, response.status_code)
 
 
 def sync_rates(app_id, date=None):

--- a/metasettings/tests/tests.py
+++ b/metasettings/tests/tests.py
@@ -155,7 +155,7 @@ class MetasettingsTests(TestCase):
             'submit': 1,
             'language_code': 'en',
             'currency_code': 'EUR',
-            'redirect_url': reverse('root')
+            'redirect_url': '/'
         })
 
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
This is part of a bigger refactoring meant to take the openexchagerates syncing out of the Django command in order to be able to use it in a Celery task
